### PR TITLE
meal plan description

### DIFF
--- a/TeamNut/Services/MealPlanService.cs
+++ b/TeamNut/Services/MealPlanService.cs
@@ -204,8 +204,8 @@ namespace TeamNut.Services
             {
                 "bulk" => $"+300 kcal (Bulking phase: {baseTDEE} + 300 = {baseTDEE + 300} kcal)",
                 "cut" => $"-300 kcal (Cutting phase: {baseTDEE} - 300 = {baseTDEE - 300} kcal)",
-                "maintenance" => $"+100 kcal (Maintenance: {baseTDEE} + 100 = {baseTDEE + 100} kcal)",
-                "well-being" => $"+100 kcal (Well-being: {baseTDEE} + 100 = {baseTDEE + 100} kcal)",
+                "maintenance" => $"No adjustment (Maintenance: {baseTDEE} kcal)",
+                "well-being" => $"No adjustment (Well-being: {baseTDEE} kcal)",
                 _ => $"No adjustment (Base TDEE: {baseTDEE} kcal)"
             };
 


### PR DESCRIPTION
In MealPlanService, in the function GetCalorieAdjustmentDescription we were mentioning that 100 kcal are added to the maintenance and well-being health goals, but in UserData in the function CalculateCalorieNeeds we weren't adding the 100 calories:

double adjustedCalories = Goal.ToLower() switch
            {
                "bulk" => tdee + 300,
                "cut" => tdee - 300,
                "maintenance" => tdee,
                "well-being" => tdee,
                _ => tdee
            };

So I synchronized the description by not adding the 100 kcal 