### PR TITLE
fix sqlite messaging, shopping list await, meal plan null goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ serviceDependencies.json
 serviceDependencies.local.json
 /TeamNut/SQLScripts/MasterSQLlitescript.sql
 /TeamNut/SQLScripts/MasterSQLlitescript_DB_browser.sql
-*.cs
-*.xaml
-/.gitignore

--- a/TeamNut/App.xaml.cs
+++ b/TeamNut/App.xaml.cs
@@ -3,7 +3,6 @@ using Microsoft.UI.Xaml.Controls;
 using TeamNut.ViewModels;
 using TeamNut.Views;
 using TeamNut.Views.UserView;
-using System.Diagnostics;
 
 namespace TeamNut
 {
@@ -21,30 +20,6 @@ namespace TeamNut
             };
 
             InitializeComponent();
-
-            EnsureLocalDbStarted();
-        }
-
-        private void EnsureLocalDbStarted()
-        {
-            try
-            {
-                var startInfo = new ProcessStartInfo
-                {
-                    FileName = "sqllocaldb",
-                    Arguments = "start MSSQLLocalDB",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
-
-                using var process = Process.Start(startInfo);
-                process?.WaitForExit();
-            }
-            catch
-            {
-            }
         }
 
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)

--- a/TeamNut/Directory.Build.targets
+++ b/TeamNut/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <!-- dotnet CLI only: skip apphost when CreateAppHost fails (HostModel / SDK mismatch). Visual Studio keeps normal apphost for F5. -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <SelfContained>false</SelfContained>
+    <UseAppHost>false</UseAppHost>
+  </PropertyGroup>
+</Project>

--- a/TeamNut/Services/UserService.cs
+++ b/TeamNut/Services/UserService.cs
@@ -22,7 +22,7 @@ namespace TeamNut.Services
             return users.Any(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
         }
 
-        public async Task<User> LoginAsync(string username, string password)
+        public async Task<User?> LoginAsync(string username, string password)
         {
             var user = await _userRepository.GetByUsernameAndPassword(username, password);
             if (user != null)
@@ -34,7 +34,7 @@ namespace TeamNut.Services
             return null;
         }
 
-        public async Task<User> RegisterUserAsync(User user)
+        public async Task<User?> RegisterUserAsync(User user)
         {
             if (await CheckIfUsernameExistsAsync(user.Username))
             {

--- a/TeamNut/TeamNut.csproj
+++ b/TeamNut/TeamNut.csproj
@@ -8,11 +8,12 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-    <!-- Set a single RuntimeIdentifier for packaging/publish to avoid the "architecture neutral" error -->
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- Do not set a global RuntimeIdentifier: it forces self-contained inference and breaks dotnet CLI apphost on some installs. Pick platform in VS or pass -r win-x64 when publishing. -->
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <WinUISDKReferences>false</WinUISDKReferences>
+    <!-- Use installed Windows App Runtime instead of self-contained (matches VibeCoders-style setup, avoids apphost/self-contained coupling on dotnet CLI) -->
+    <WindowsAppSDKSelfContained>false</WindowsAppSDKSelfContained>
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -25,10 +26,6 @@
     <None Remove="Views\UserView\UserDataPage.xaml" />
 	<None Remove="Views\MainPage.xaml" />
 	<None Remove="Views\CalorieLoggingView\CalorieLoggingPage.xaml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="obj\x64\Debug\net8.0-windows10.0.19041.0\win-x64\App.g.i.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -115,4 +112,5 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
 </Project>

--- a/TeamNut/ViewModels/UserViewModel.cs
+++ b/TeamNut/ViewModels/UserViewModel.cs
@@ -148,7 +148,7 @@ namespace TeamNut.ViewModels
             }
             catch (Exception ex)
             {
-                StatusMessage = "Database Connection Failed! Start SSMS and check your server. Error: " + ex.Message;
+                StatusMessage = "Could not reach the local database (NutData.db). Check the file is next to the project and you have read/write access. " + ex.Message;
             }
         }
     }

--- a/TeamNut/Views/MainPage.xaml.cs
+++ b/TeamNut/Views/MainPage.xaml.cs
@@ -62,7 +62,10 @@ namespace TeamNut.Views
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ReminderTimer_Tick: {ex}");
+            }
         }
 
         private async System.Threading.Tasks.Task ShowReminderDialog(TeamNut.Models.Reminder rem)
@@ -112,7 +115,10 @@ namespace TeamNut.Views
                     
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ShowReminderDialog: {ex}");
+            }
         }
 
         private void OnRemindersChanged(object? sender, int userId)

--- a/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
+++ b/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
@@ -181,7 +181,21 @@ namespace TeamNut.Views.MealPlanView
                 userData.Weight = (int)weightBox.Value;
                 userData.Height = (int)heightBox.Value;
                 userData.Gender = genderCombo.SelectedIndex == 0 ? "male" : "female";
-                userData.Goal = goalCombo.SelectedItem.ToString().ToLower();
+                var goalText = goalCombo.SelectedItem?.ToString();
+                if (string.IsNullOrWhiteSpace(goalText))
+                {
+                    var goalDialog = new ContentDialog
+                    {
+                        Title = "Invalid Input",
+                        Content = "Please select a goal.",
+                        CloseButtonText = "OK",
+                        XamlRoot = this.XamlRoot
+                    };
+                    _ = await goalDialog.ShowAsync();
+                    return;
+                }
+
+                userData.Goal = goalText.ToLowerInvariant();
 
                 userData.Bmi = userData.CalculateBmi();
                 userData.CalorieNeeds = userData.CalculateCalorieNeeds();

--- a/TeamNut/Views/ShoppingListView/ShoppingListPage.xaml.cs
+++ b/TeamNut/Views/ShoppingListView/ShoppingListPage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -18,12 +19,12 @@ namespace TeamNut.Views.ShoppingListView
             this.Name = "RootPage";
         }
 
-        private void AddButton_Click(object sender, RoutedEventArgs e)
+        private async void AddButton_Click(object sender, RoutedEventArgs e)
         {
             var text = IngredientSearchBox.Text;
             if (!string.IsNullOrWhiteSpace(text) && text != "no matching ingredients found")
             {
-                ViewModel.AddItem(text);
+                await ViewModel.AddItem(text).ConfigureAwait(true);
                 IngredientSearchBox.Text = string.Empty;
                 IngredientSearchBox.ItemsSource = null;
             }
@@ -54,7 +55,8 @@ namespace TeamNut.Views.ShoppingListView
 
         private void IngredientSearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
         {
-            var selectedName = args.SelectedItem.ToString();
+            var selectedName = args.SelectedItem?.ToString();
+            if (selectedName == null) return;
             if (selectedName == "no matching ingredients found")
             {
                 sender.Text = "";

--- a/TeamNut/run-debug.cmd
+++ b/TeamNut/run-debug.cmd
@@ -1,0 +1,11 @@
+@echo off
+cd /d "%~dp0"
+dotnet build -c Debug -p:Platform=x64 || exit /b 1
+echo.
+echo If the window does not open or you see Class not registered, install Windows App Runtime 1.8 x64:
+echo https://learn.microsoft.com/windows/apps/windows-app-sdk/downloads
+echo.
+echo Easiest path: open TeamNut in Visual Studio, pick profile TeamNut (Unpackaged), press F5.
+echo.
+cd bin\x64\Debug\net8.0-windows10.0.19041.0\win-x64
+dotnet exec TeamNut.dll


### PR DESCRIPTION
Few things that weren't working properly:

- Login error message was pointing to SSMS/SQL Server when the app actually uses SQLite - confusing for anyone trying to debug auth issues
- Shopping list Add wasn't awaiting the async AddItem call so items could appear to add but fail silently
- Meal plan page was crashing when goal was null on the user profile
- Removed the LocalDB stub from App.xaml.cs that was trying to spin up SQL Server on launch (not needed, we're on SQLite)
- Fixed the .gitignore that was accidentally excluding .cs and .xaml files
- Added Directory.Build.targets and run-debug.cmd to make the WinUI CLI build work