### PR TITLE
fix a few runtime bugs found during testing

### DIFF
--- a/TeamNut/Models/Reminder.cs
+++ b/TeamNut/Models/Reminder.cs
@@ -25,11 +25,11 @@ namespace TeamNut.Models
         [Required]
         public partial TimeSpan Time { get; set; }
 
-        public string ReminderDate { get; set; }
+        public string ReminderDate { get; set; } = string.Empty;
 
         [ObservableProperty]
         public partial string Frequency { get; set; } = "Once";
 
-        public string FullDateTimeDisplay => $"{ReminderDate} at {Time}"; 
+        public string FullDateTimeDisplay => $"{ReminderDate ?? "No date"} at {Time}";
     }
 }

--- a/TeamNut/Models/UserData.cs
+++ b/TeamNut/Models/UserData.cs
@@ -152,7 +152,7 @@ namespace TeamNut.Models
 
             int proteinCalories = protein * 4;
             int fatCalories = fat * 9;
-            int carbCalories = calories - proteinCalories - fatCalories;
+            int carbCalories = Math.Max(0, calories - proteinCalories - fatCalories);
 
             return (int)Math.Round(carbCalories / 4.0);
         }

--- a/TeamNut/Repositories/ChatRepository.cs
+++ b/TeamNut/Repositories/ChatRepository.cs
@@ -135,13 +135,8 @@ namespace TeamNut.Repositories
                     SenderUsername = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
                     SenderRole = reader.IsDBNull(6) ? string.Empty : reader.GetString(6)
                 });
-                // set helper fields
                 var last = list[list.Count - 1];
-                try
-                {
-                    last.IsFromCurrentUser = last.SenderId == TeamNut.Models.UserSession.UserId;
-                }
-                catch { }
+                last.IsFromCurrentUser = UserSession.UserId.HasValue && last.SenderId == UserSession.UserId.Value;
             }
             return list;
         }

--- a/TeamNut/Repositories/MealPlanRepository.cs
+++ b/TeamNut/Repositories/MealPlanRepository.cs
@@ -581,6 +581,8 @@ namespace TeamNut.Repositories
 
         public async Task SaveMealsToDailyLog(int userId, List<Meal> meals)
         {
+            if (meals == null || meals.Count == 0) return;
+
             using var conn = new SqliteConnection(_connectionString);
             await conn.OpenAsync();
 

--- a/TeamNut/Repositories/ShoppingListRepository.cs
+++ b/TeamNut/Repositories/ShoppingListRepository.cs
@@ -16,7 +16,8 @@ namespace TeamNut.Repositories
             await conn.OpenAsync();
 
             string query = @"INSERT INTO ShoppingItems (user_id, ingredient_id, quantity_grams, is_checked)
-                             VALUES (@userId, @ingredientId, @quantityGrams, @isChecked)";
+                             VALUES (@userId, @ingredientId, @quantityGrams, @isChecked);
+                             SELECT last_insert_rowid();";
 
             using var cmd = new SqliteCommand(query, conn);
             cmd.Parameters.AddWithValue("@userId", item.UserId);
@@ -24,7 +25,9 @@ namespace TeamNut.Repositories
             cmd.Parameters.AddWithValue("@quantityGrams", item.QuantityGrams);
             cmd.Parameters.AddWithValue("@isChecked", item.IsChecked ? 1 : 0);
 
-            await cmd.ExecuteNonQueryAsync();
+            var result = await cmd.ExecuteScalarAsync();
+            if (result != null)
+                item.Id = Convert.ToInt32(result);
         }
 
         public async Task<IEnumerable<ShoppingItem>> GetAll()

--- a/TeamNut/Services/InventoryService.cs
+++ b/TeamNut/Services/InventoryService.cs
@@ -24,10 +24,10 @@ namespace TeamNut.Services
         {
             
             var requiredIngredients = await _mealPlanRepository.GetIngredientsForMeal(mealId);
+            var inventoryItems = (await _inventoryRepository.GetAllByUserId(userId)).ToList();
 
             foreach (var req in requiredIngredients)
             {
-                var inventoryItems = await _inventoryRepository.GetAllByUserId(userId);
                 var stock = inventoryItems.FirstOrDefault(i => i.IngredientId == req.IngredientId);
 
                 if (stock != null)

--- a/TeamNut/Services/ShoppingListService.cs
+++ b/TeamNut/Services/ShoppingListService.cs
@@ -136,8 +136,8 @@ namespace TeamNut.Services
 
                     if (totalNeeded > 0)
                     {
-                        await AddItemAsync(needed.IngredientName, userId, totalNeeded);
-                        itemsAddedCount++;
+                        var added = await AddItemAsync(needed.IngredientName, userId, totalNeeded);
+                        if (added != null) itemsAddedCount++;
                     }
                 }
 

--- a/TeamNut/ViewModels/MealPlanViewModel.cs
+++ b/TeamNut/ViewModels/MealPlanViewModel.cs
@@ -195,7 +195,7 @@ namespace TeamNut.ModelViews
 
                 var (totalCalories, totalProtein, totalCarbs, totalFat) = _mealPlanService.CalculateTotalNutrition(meals);
 
-                string goalName = char.ToUpper(userGoal[0]) + userGoal.Substring(1);
+                string goalName = string.IsNullOrEmpty(userGoal) ? "Maintenance" : char.ToUpper(userGoal[0]) + userGoal.Substring(1);
                 GoalDescription = $"{goalName} Goal";
 
                 TotalNutritionSummary = $"Daily Total: {totalCalories} kcal | {totalProtein}g protein | {totalCarbs}g carbs | {totalFat}g fat";


### PR DESCRIPTION
Went through the codebase looking for issues and found a few things that would cause actual crashes or wrong data at runtime.

**Reminder date display** - ReminderDate had no default value so FullDateTimeDisplay would throw a NullReferenceException on any reminder created without a date set explicitly. Added the empty string default and a null fallback in the display string.

**Carb calculation** - if the protein + fat macros happen to exceed total calories (can happen with aggressive cut goals and low calorie targets), carbCalories goes negative and the method returns a negative number. Clamped it to 0.

**Chat messages** - IsFromCurrentUser was wrapped in an empty try/catch for no reason, which would silently leave it false if UserSession.UserId was null. Replaced with a proper null check. Also SaveMealsToDailyLog in MealPlanRepository had no guard against a null or empty meals list, which would open a DB connection and do nothing - added an early return.

**Meal plan goal name** - MealPlanViewModel was doing userGoal[0] to capitalize the goal name without checking if the string was empty first. If GetUserGoalAsync ever returns an empty string the whole page crashes.

**Shopping item id** - ShoppingListRepository.Add was inserting the row but never reading back last_insert_rowid(), so item.Id stayed 0 after insert. Anything that tried to update or delete that item by id would silently operate on the wrong row.

**Inventory query in loop** - ConsumeMeal in InventoryService was calling GetAllByUserId inside the foreach, so for a 3-meal plan that's 3 separate DB reads of the same data. Moved it outside the loop.

**Shopping list generate count** - GenerateListAsync was incrementing itemsAddedCount even when AddItemAsync returned null (i.e. failed). The count shown to the user would be wrong. Added a null check before counting.