### PR TITLE
fix edge cases caught during testing

### DIFF
--- a/TeamNut/Models/UserData.cs
+++ b/TeamNut/Models/UserData.cs
@@ -220,7 +220,7 @@ namespace TeamNut.Models
                 return 0;
             }
 
-            int carbCalories = calories - proteinCalories - fatCalories;
+            int carbCalories = Math.Max(0, calories - proteinCalories - fatCalories);
             return (int)Math.Round(carbCalories / (double)CaloriesPerGramCarbs);
         }
     }

--- a/TeamNut/Repositories/ChatRepository.cs
+++ b/TeamNut/Repositories/ChatRepository.cs
@@ -30,7 +30,7 @@ namespace TeamNut.Repositories
                     Id = reader.GetInt32(0),
                     HasUnanswered = Convert.ToBoolean(reader.GetValue(1)),
                     UserId = reader.GetInt32(2),
-                    Username = reader.GetString(3),
+                    Username = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
                 });
             }
             return list;

--- a/TeamNut/Services/InventoryService.cs
+++ b/TeamNut/Services/InventoryService.cs
@@ -31,20 +31,22 @@ namespace TeamNut.Services
             foreach (var req in requiredIngredients)
             {
                 var stock = inventoryItems.FirstOrDefault(i => i.IngredientId == req.IngredientId);
+                int qtyToRemove = (int)Math.Round(req.Quantity);
 
-                if (stock != null)
+                if (stock == null || stock.QuantityGrams < qtyToRemove)
                 {
-                    int qtyToRemove = (int)Math.Round(req.Quantity);
-                    stock.QuantityGrams -= qtyToRemove;
+                    return false;
+                }
 
-                    if (stock.QuantityGrams <= 0)
-                    {
-                        await inventoryRepository.Delete(stock.Id);
-                    }
-                    else
-                    {
-                        await inventoryRepository.Update(stock);
-                    }
+                stock.QuantityGrams -= qtyToRemove;
+
+                if (stock.QuantityGrams <= 0)
+                {
+                    await inventoryRepository.Delete(stock.Id);
+                }
+                else
+                {
+                    await inventoryRepository.Update(stock);
                 }
             }
 

--- a/TeamNut/Services/MealPlanService.cs
+++ b/TeamNut/Services/MealPlanService.cs
@@ -319,8 +319,8 @@ namespace TeamNut.Services
                 var userData =
                     await userRepository.GetUserDataByUserId(userId);
 
-                return userData?.Goal?.ToLower()
-                    ?? GoalMaintenance;
+                var goal = userData?.Goal?.Trim().ToLowerInvariant();
+                return string.IsNullOrEmpty(goal) ? GoalMaintenance : goal;
             }
             catch
             {

--- a/TeamNut/Services/ReminderService.cs
+++ b/TeamNut/Services/ReminderService.cs
@@ -86,20 +86,21 @@ namespace TeamNut.Services
 
         public async Task DeleteReminder(int id)
         {
-            try
+            var existing =
+                await reminderRepository.GetById(id);
+
+            await reminderRepository.Delete(id);
+
+            if (existing != null)
             {
-                var existing =
-                    await reminderRepository.GetById(id);
-
-                await reminderRepository.Delete(id);
-
-                if (existing != null)
+                try
                 {
                     RemindersChanged?.Invoke(this, existing.UserId);
                 }
-            }
-            catch
-            {
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"RemindersChanged handler failed: {ex.Message}");
+                }
             }
         }
 

--- a/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
+++ b/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
@@ -39,7 +39,7 @@ namespace TeamNut.Views.MealPlanView
         private const string MsgNoMealPlanLoaded = "No meal plan is currently loaded. Please generate a meal plan first.";
         private const string MsgNoMealsGenerated = "No meals to save. Please generate a meal plan first.";
         private const string MsgPreferenceInfo = "Changes will be reflected in your next meal plan generation.";
-        private const string MealBullet = "�";
+        private const string MealBullet = "\u2022";
         private const string KcalUnit = "kcal";
         private const int WeightMin = 1;
         private const int WeightMax = 500;


### PR DESCRIPTION
Found a few more issues while testing different user flows:

- **Negative carb values**: `CalculateCarbNeeds()` could go negative when protein+fat calories exceeded the total (e.g. extreme cut goals). Clamped to zero.
- **Empty goal crash**: if the user's goal was saved as an empty string in the db, the capitalize logic in the meal plan view would crash on `userGoal[0]`. Added a proper check in `GetUserGoalAsync` so it falls back to "maintenance".
- **Chat username null**: `GetAllConversationsAsync` assumed username was always non-null from the join, but deleted users could leave nulls. Now handles it like the other reader methods do.
- **Broken bullet char**: the meal plan success dialog had a mojibake character instead of a bullet point (encoding issue from a previous commit).
- **ConsumeMeal always returning true**: even when an ingredient was missing from inventory or there wasn't enough stock, the method returned `true`. Now returns `false` early so the UI can actually tell the user something's wrong.
- **Silent delete failures in reminders**: `DeleteReminder` had a bare catch block that swallowed everything including actual db errors. Moved the try/catch to only wrap the event notification (where subscriber errors are expected).
