### PR TITLE
null safety guards across services and calculations

### DIFF
--- a/TeamNut/Models/UserData.cs
+++ b/TeamNut/Models/UserData.cs
@@ -220,7 +220,7 @@ namespace TeamNut.Models
                 return 0;
             }
 
-            int carbCalories = calories - proteinCalories - fatCalories;
+            int carbCalories = Math.Max(0, calories - proteinCalories - fatCalories);
             return (int)Math.Round(carbCalories / (double)CaloriesPerGramCarbs);
         }
     }

--- a/TeamNut/Services/FilteringService.cs
+++ b/TeamNut/Services/FilteringService.cs
@@ -26,7 +26,7 @@ namespace TeamNut.Services
             }
 
             return meals
-                .Where(m => m.Name.Contains(query, comparison))
+                .Where(m => m.Name?.Contains(query, comparison) == true)
                 .ToList();
         }
 

--- a/TeamNut/Services/MealPlanService.cs
+++ b/TeamNut/Services/MealPlanService.cs
@@ -319,8 +319,8 @@ namespace TeamNut.Services
                 var userData =
                     await userRepository.GetUserDataByUserId(userId);
 
-                return userData?.Goal?.ToLower()
-                    ?? GoalMaintenance;
+                var goal = userData?.Goal?.Trim().ToLowerInvariant();
+                return string.IsNullOrEmpty(goal) ? GoalMaintenance : goal;
             }
             catch
             {

--- a/TeamNut/Services/NutritionCalculationService.cs
+++ b/TeamNut/Services/NutritionCalculationService.cs
@@ -91,6 +91,7 @@ namespace TeamNut.Services
 
             double tdee = bmr * ActivityMultiplier;
 
+            goal = goal ?? string.Empty;
             double adjustedCalories = goal.ToLower() switch
             {
                 GoalBulk => tdee + BulkCalorieDelta,
@@ -110,6 +111,7 @@ namespace TeamNut.Services
                 return 0;
             }
 
+            goal = goal ?? string.Empty;
             double proteinPerKg = goal.ToLower() switch
             {
                 GoalBulk => ProteinBulk,
@@ -129,6 +131,7 @@ namespace TeamNut.Services
                 return 0;
             }
 
+            goal = goal ?? string.Empty;
             double fatRatio = goal.ToLower() switch
             {
                 GoalBulk or GoalCut => FatBulkCut,
@@ -151,7 +154,7 @@ namespace TeamNut.Services
                 return 0;
             }
 
-            int carbCalories = calorieNeeds - proteinCalories - fatCalories;
+            int carbCalories = Math.Max(0, calorieNeeds - proteinCalories - fatCalories);
             return (int)Math.Round(carbCalories / (double)CaloriesPerGramCarbs);
         }
 

--- a/TeamNut/Services/UserService.cs
+++ b/TeamNut/Services/UserService.cs
@@ -24,7 +24,7 @@ namespace TeamNut.Services
         public async Task<bool> CheckIfUsernameExistsAsync(string username)
         {
             var users = await userRepository.GetAll();
-            return users.Any(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+            return users.Any(u => string.Equals(u.Username, username, StringComparison.OrdinalIgnoreCase));
         }
 
         public async Task<User?> LoginAsync(string username, string password)


### PR DESCRIPTION
Went through a bunch of the calculation and service code and found some places where null/empty inputs could crash things:

- carb calculation in both UserData and NutritionCalculationService could return negative grams when protein+fat exceeded the calorie budget — clamped to zero
- `GetUserGoalAsync` was using `??` which doesn't catch empty strings, so if the goal was `""` in the db it'd pass through and crash the capitalize logic downstream
- same kind of issue in NutritionCalculationService — `goal.ToLower()` called three times without null checks
- `CheckIfUsernameExistsAsync` was calling `.Equals` on `u.Username` which blows up if any user has a null username row
- meal search filter was doing `m.Name.Contains(...)` without null check — one bad meal row kills the whole search

closes #61, closes #62, closes #80, closes #81, closes #83
