### PR TITLE
fix chat, inventory, and reminder bugs

### DIFF
--- a/TeamNut/Repositories/ChatRepository.cs
+++ b/TeamNut/Repositories/ChatRepository.cs
@@ -30,7 +30,7 @@ namespace TeamNut.Repositories
                     Id = reader.GetInt32(0),
                     HasUnanswered = Convert.ToBoolean(reader.GetValue(1)),
                     UserId = reader.GetInt32(2),
-                    Username = reader.GetString(3),
+                    Username = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
                 });
             }
             return list;

--- a/TeamNut/Services/InventoryService.cs
+++ b/TeamNut/Services/InventoryService.cs
@@ -31,20 +31,22 @@ namespace TeamNut.Services
             foreach (var req in requiredIngredients)
             {
                 var stock = inventoryItems.FirstOrDefault(i => i.IngredientId == req.IngredientId);
+                int qtyToRemove = (int)Math.Round(req.Quantity);
 
-                if (stock != null)
+                if (stock == null || stock.QuantityGrams < qtyToRemove)
                 {
-                    int qtyToRemove = (int)Math.Round(req.Quantity);
-                    stock.QuantityGrams -= qtyToRemove;
+                    return false;
+                }
 
-                    if (stock.QuantityGrams <= 0)
-                    {
-                        await inventoryRepository.Delete(stock.Id);
-                    }
-                    else
-                    {
-                        await inventoryRepository.Update(stock);
-                    }
+                stock.QuantityGrams -= qtyToRemove;
+
+                if (stock.QuantityGrams <= 0)
+                {
+                    await inventoryRepository.Delete(stock.Id);
+                }
+                else
+                {
+                    await inventoryRepository.Update(stock);
                 }
             }
 

--- a/TeamNut/Services/ReminderService.cs
+++ b/TeamNut/Services/ReminderService.cs
@@ -86,20 +86,21 @@ namespace TeamNut.Services
 
         public async Task DeleteReminder(int id)
         {
-            try
+            var existing =
+                await reminderRepository.GetById(id);
+
+            await reminderRepository.Delete(id);
+
+            if (existing != null)
             {
-                var existing =
-                    await reminderRepository.GetById(id);
-
-                await reminderRepository.Delete(id);
-
-                if (existing != null)
+                try
                 {
                     RemindersChanged?.Invoke(this, existing.UserId);
                 }
-            }
-            catch
-            {
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"RemindersChanged handler error: {ex.Message}");
+                }
             }
         }
 

--- a/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
+++ b/TeamNut/Views/MealPlanView/MealPlanPage.xaml.cs
@@ -39,7 +39,7 @@ namespace TeamNut.Views.MealPlanView
         private const string MsgNoMealPlanLoaded = "No meal plan is currently loaded. Please generate a meal plan first.";
         private const string MsgNoMealsGenerated = "No meals to save. Please generate a meal plan first.";
         private const string MsgPreferenceInfo = "Changes will be reflected in your next meal plan generation.";
-        private const string MealBullet = "�";
+        private const string MealBullet = "\u2022";
         private const string KcalUnit = "kcal";
         private const int WeightMin = 1;
         private const int WeightMax = 500;

--- a/TeamNut/Views/RemindersView/RemindersPage.xaml.cs
+++ b/TeamNut/Views/RemindersView/RemindersPage.xaml.cs
@@ -99,12 +99,20 @@ namespace TeamNut.Views.RemindersView
                     freqCombo.Items.Add(FrequencyWeekly);
                     freqCombo.Items.Add(FrequencyMonthly);
 
-                    freqCombo.SelectedIndex =
-                        string.IsNullOrWhiteSpace(reminder.Frequency)
-                            ? 0
-                            : Math.Max(
-                                freqCombo.Items.IndexOf(reminder.Frequency),
-                                0);
+                    int freqIndex = 0;
+                    if (!string.IsNullOrWhiteSpace(reminder.Frequency))
+                    {
+                        for (int fi = 0; fi < freqCombo.Items.Count; fi++)
+                        {
+                            if (string.Equals(freqCombo.Items[fi]?.ToString(), reminder.Frequency, StringComparison.OrdinalIgnoreCase))
+                            {
+                                freqIndex = fi;
+                                break;
+                            }
+                        }
+                    }
+
+                    freqCombo.SelectedIndex = freqIndex;
 
                     panel.Children.Add(new TextBlock { Text = LabelName });
                     panel.Children.Add(nameBox);


### PR DESCRIPTION
Bunch of fixes found while testing the chat, inventory, and reminders flows:

- conversation list was crashing when a user got deleted but their conversations were still in the db — username column came back null and `GetString` doesn't like that
- the bullet character in the "meals saved" dialog was garbled (encoding got messed up somewhere), replaced with a proper unicode bullet
- `ConsumeMeal` was always returning true even if the user didn't have enough of an ingredient — the UI had no way to know it failed. now it checks stock before deducting and returns false early
- `DeleteReminder` had the entire method wrapped in a bare catch block, including the actual db delete call. moved the try/catch to only wrap the event notification part
- reminder edit dialog was picking the wrong frequency because `IndexOf` is case-sensitive and the db might store lowercase

closes #63, closes #64, closes #65, closes #66, closes #82
