### PR TITLE
fix event handler leaks and lifecycle cleanup

### DIFF
--- a/TeamNut/ViewModels/NutritionistChatViewModel.cs
+++ b/TeamNut/ViewModels/NutritionistChatViewModel.cs
@@ -229,7 +229,12 @@ namespace TeamNut.ViewModels
                 currentConversationId = conv.Id;
             }
 
-            int senderId = UserSession.UserId ?? InvalidUserId;
+            if (UserSession.UserId == null)
+            {
+                return;
+            }
+
+            int senderId = UserSession.UserId.Value;
             bool isNutritionist = UserSession.Role == NutritionistRole;
 
             await chatService.AddMessageAsync(

--- a/TeamNut/ViewModels/RemindersViewModel.cs
+++ b/TeamNut/ViewModels/RemindersViewModel.cs
@@ -10,8 +10,9 @@ using TeamNut.Services;
 using TeamNut.Services.Interfaces;
 namespace TeamNut.ViewModels
 {
-    public partial class RemindersViewModel : ObservableObject
+    public partial class RemindersViewModel : ObservableObject, IDisposable
     {
+        private bool disposed;
         private readonly IReminderService reminderService;
         private readonly DispatcherQueue? dispatcher;
         private const int InvalidUserId = 0;
@@ -165,6 +166,15 @@ namespace TeamNut.ViewModels
             else
             {
                 action();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                reminderService.RemindersChanged -= OnRemindersChanged;
+                disposed = true;
             }
         }
     }

--- a/TeamNut/ViewModels/UserViewModel.cs
+++ b/TeamNut/ViewModels/UserViewModel.cs
@@ -150,6 +150,7 @@ namespace TeamNut.ViewModels
 
                 if (user != null)
                 {
+                    CurrentUser = user;
                     LoginSuccess?.Invoke(this, EventArgs.Empty);
                 }
                 else

--- a/TeamNut/Views/MainPage.xaml.cs
+++ b/TeamNut/Views/MainPage.xaml.cs
@@ -60,6 +60,15 @@ namespace TeamNut.Views
             };
             reminderTimer.Tick += ReminderTimer_Tick;
             reminderTimer.Start();
+
+            this.Unloaded += MainPage_Unloaded;
+        }
+
+        private void MainPage_Unloaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            reminderTimer.Stop();
+            reminderTimer.Tick -= ReminderTimer_Tick;
+            reminderService.RemindersChanged -= OnRemindersChanged;
         }
 
         private async void ReminderTimer_Tick(object? sender, object? e)

--- a/TeamNut/Views/UserView/RegisterPage.xaml.cs
+++ b/TeamNut/Views/UserView/RegisterPage.xaml.cs
@@ -16,19 +16,20 @@ namespace TeamNut.Views.UserView
             InitializeComponent();
             ViewModel = App.Services.GetRequiredService<UserViewModel>();
             this.DataContext = ViewModel;
-            ViewModel.RegistrationValid += ViewModel_RegistrationValid;
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
             ViewModel.LoginSuccess += ViewModel_LoginSuccess;
+            ViewModel.RegistrationValid += ViewModel_RegistrationValid;
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             base.OnNavigatedFrom(e);
             ViewModel.LoginSuccess -= ViewModel_LoginSuccess;
+            ViewModel.RegistrationValid -= ViewModel_RegistrationValid;
         }
 
         private void ViewModel_LoginSuccess(object? sender, EventArgs e)


### PR DESCRIPTION
Found a few places where event handlers were leaking or lifecycle wasn't being cleaned up properly:

- `RemindersViewModel` subscribes to `RemindersChanged` on the singleton service but never unsubscribes. Opening reminders multiple times stacks handlers and causes duplicate db loads. Added `IDisposable` with the unsub.
- `RegisterPage` was subscribing to `RegistrationValid` in the constructor (which runs every time you navigate there) but never unsubscribing. `LoginSuccess` already had the right pattern with `OnNavigatedTo/From`, so moved `RegistrationValid` to match.
- Chat send was falling through to `AddMessageAsync` with `senderId = 0` if `UserId` was null on the nutritionist path. Added a null check before the send.
- After login, `CurrentUser` was still the form-bound object with `Id = 0`. Anything reading `CurrentUser.Id` after login got the wrong value. Now we assign the real user object back.
- `MainPage` was subscribing to `RemindersChanged` and starting a `DispatcherTimer` but never cleaning up on unload. After logout/re-login you'd get duplicate timers and event handlers piling up. Added an `Unloaded` handler to stop the timer and unsub.

closes #78, closes #79, closes #84, closes #85, closes #86
